### PR TITLE
Prevent Rterm from crashing if images are missing on startup.

### DIFF
--- a/lib/Resurrection/imlib2.c
+++ b/lib/Resurrection/imlib2.c
@@ -212,12 +212,11 @@ R_render_image_imlib2(struct R_image *image,
     int xofs = 0;
     int yofs = 0;
 
-#if 0
-    if (!image || !image->orig || !window->id) {
 
+    if (!image || !image->orig || !window->id) {
         return -1;
     }
-#endif
+
     R_free_image_imlib2(image);
     if (image->flags & R_IMAGE_STATIC_FLAG) {
         if (image->pixmap) {
@@ -635,6 +634,9 @@ R_set_image_border_imlib2(struct R_image *image,
                           int left,
                           int right)
 {
+  if(image == NULL) { return; }
+  if(image->orig == NULL) { return; }
+
     Imlib_Border border;
 
     border.top = top;

--- a/lib/Rterm/draw.c
+++ b/lib/Rterm/draw.c
@@ -1246,6 +1246,7 @@ Rterm_clear_screen_cursor(struct R_termscreen *screen)
 {
     int row;
     int column;
+    int textflags = 1;
 
     if (screen == NULL) {
 
@@ -1259,7 +1260,7 @@ Rterm_clear_screen_cursor(struct R_termscreen *screen)
                                       row, column,
                                       &screen->textbuf.data[screen->viewrow + row][column],
                                       &screen->drawbuf.data[screen->viewrow + row][column],
-                                      1,
+                                      &textflags,
                                       RTERM_SCREEN_DRAW_ALL,
                                       TRUE);
         screen->drawbuf.renddata[row][column] &= ~RTERM_CHAR_CURSOR;

--- a/lib/Rterm/screen.c
+++ b/lib/Rterm/screen.c
@@ -193,6 +193,7 @@ Rterm_load_screen_draw_image(struct R_termscreen *screen)
                             &screen->drawimage);
                             
     } else {
+        
         R_load_image_imlib2(app,
                             RESURRECTION_IMAGE_SEARCH_PATH "background/darkstone.png",
                             &screen->drawimage);


### PR DESCRIPTION
Rterm when starting relies on certain images to be present, otherwise the calls to some draw functions will fail. I've also added error checking for border drawing and a pointer bug. The pointer bug was the program trying to access a pointer to a constant which was out of bounds. Changing the constant to a variable and taking the lvalue (&) fixed that.
